### PR TITLE
Port ConvertArea function

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Turf for Go is a ported library in GoLang ported from the Turf.js library.
 
 ## Unit Conversion 
 - [x] bearingToAzimuth
-- [ ]  convertArea
+- [x]  convertArea
 - [x]  convertLength
 - [x] degreesToRadians
 - [x]  lengthToRadians

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -1,6 +1,14 @@
 package constants
 
 const (
+	// UnitAcresis a unit of land measurement in the British Imperial and United States Customary systems, equal to 43,560 square feet, or 4,840 square yards. One acre is equivalent to 0.4047 hectare (4,047 square metres
+	UnitAcres = "acres"
+	// UnitHectares is a unit of area in the metric system equal to 100 ares, or 10,000 square metres, and the equivalent of 2.471 acres in the British Imperial System and the United States Customary measure. The term is derived from the Latin area and from hect, an irregular contraction of the Greek word for hundred.
+	UnitHectares = "hectares"
+	// UnitMillimeters spelled as millimeter, unit of length equal to 0.001 metre in the metric system and the equivalent of 0.03937 inch
+	UnitMillimeters = "millimeters"
+	// UnitMillimetres spelled as millimeter, unit of length equal to 0.001 metre in the metric system and the equivalent of 0.03937 inch
+	UnitMillimetres = "millimetres"
 	// UnitMiles is an English unit of length of linear measure equal to 5.280 feet, or 1.760 yards, and standardised as exactly 1,609.344 meters by international agreement in 1959.
 	UnitMiles = "miles"
 	// UnitNauticalMiles us known as the knot. Nautical miles and knots are almost universally used for aeronautical and maritime navigation, because of their relationship with degrees and minutes of latitute

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -7,7 +7,7 @@ const (
 	UnitHectares = "hectares"
 	// UnitMillimeters spelled as millimeter, unit of length equal to 0.001 metre in the metric system and the equivalent of 0.03937 inch
 	UnitMillimeters = "millimeters"
-	// UnitMillimetres spelled as millimeter, unit of length equal to 0.001 metre in the metric system and the equivalent of 0.03937 inch
+	// UnitMillimetres spelled as millimetre, unit of length equal to 0.001 metre in the metric system and the equivalent of 0.03937 inch
 	UnitMillimetres = "millimetres"
 	// UnitMiles is an English unit of length of linear measure equal to 5.280 feet, or 1.760 yards, and standardised as exactly 1,609.344 meters by international agreement in 1959.
 	UnitMiles = "miles"

--- a/conversions/conversions.go
+++ b/conversions/conversions.go
@@ -23,6 +23,23 @@ var factors = map[string]float64{
 	constants.UnitKimometres:    constants.EarthRadius / 1000.0,
 }
 
+var areaFactors = map[string]float64{
+	constants.UnitAcres:       0.000247105,
+	constants.UnitCentimeters: 10000.0,
+	constants.UnitCentimetres: 1000.0,
+	constants.UnitFeet:        10.763910417,
+	constants.UnitHectares:    0.0001,
+	constants.UnitInches:      1550.003100006,
+	constants.UnitKilometers:  0.000001,
+	constants.UnitKimometres:  0.000001,
+	constants.UnitMeters:      1.0,
+	constants.UnitMetres:      1.0,
+	constants.UnitMiles:       3.86e-7,
+	constants.UnitMillimeters: 1000000.0,
+	constants.UnitMillimetres: 1000000.0,
+	constants.UnitYards:       1.195990046,
+}
+
 // DegreesToRadians converts an angle in degrees to radians.
 // degrees angle between 0 and 360
 func DegreesToRadians(degrees float64) float64 {
@@ -42,6 +59,10 @@ func ToKilometersPerHour(knots float64) float64 {
 // LengthToDegrees convert a distance measurement (assuming a spherical Earth) from a real-world unit into degrees
 // Valid units: miles, nauticalmiles, inches, yards, meters, metres, centimeters, kilometres, feet
 func LengthToDegrees(distance float64, units string) (float64, error) {
+	if units == "" {
+		units = constants.UnitDefault
+	}
+
 	ltr, err := LengthToRadians(distance, units)
 	if err != nil {
 		return 0.0, err
@@ -77,6 +98,10 @@ func RadiansToLength(radians float64, units string) (float64, error) {
 
 // ConvertLength converts a distance to a different unit specified.
 func ConvertLength(distance float64, originalUnits string, finalUnits string) (float64, error) {
+	if originalUnits == "" {
+		originalUnits = constants.UnitMeters
+	}
+
 	if finalUnits == "" {
 		finalUnits = constants.UnitDefault
 	}
@@ -87,6 +112,36 @@ func ConvertLength(distance float64, originalUnits string, finalUnits string) (f
 		return 0, err
 	}
 	return RadiansToLength(ltr, finalUnits)
+}
+
+// ConvertArea converts an area to the requested unit
+func ConvertArea(area float64, originalUnits string, finalUnits string) (float64, error) {
+	if originalUnits == "" {
+		originalUnits = constants.UnitMeters
+	}
+
+	if finalUnits == "" {
+		finalUnits = constants.UnitKilometers
+	}
+	if area < 0 {
+		return 0.0, errors.New("area must be a positive number")
+	}
+
+	if !validateAreaUnit(originalUnits) {
+		return 0.0, errors.New("invalid original units")
+	}
+
+	if !validateAreaUnit(finalUnits) {
+		return 0.0, errors.New("invalid finalUnits units")
+	}
+	startFactor := areaFactors[originalUnits]
+	finalFactor := areaFactors[finalUnits]
+	return (area / startFactor) * finalFactor, nil
+}
+
+func validateAreaUnit(units string) bool {
+	_, ok := areaFactors[units]
+	return ok
 }
 
 func validateUnit(units string) bool {

--- a/conversions/conversions.go
+++ b/conversions/conversions.go
@@ -26,7 +26,7 @@ var factors = map[string]float64{
 var areaFactors = map[string]float64{
 	constants.UnitAcres:       0.000247105,
 	constants.UnitCentimeters: 10000.0,
-	constants.UnitCentimetres: 1000.0,
+	constants.UnitCentimetres: 10000.0,
 	constants.UnitFeet:        10.763910417,
 	constants.UnitHectares:    0.0001,
 	constants.UnitInches:      1550.003100006,

--- a/conversions/conversions_test.go
+++ b/conversions/conversions_test.go
@@ -120,6 +120,10 @@ func TestConvertArea(t *testing.T) {
 	assert.Equal(t, err, nil)
 	assert.Equal(t, a, 0.001)
 
+	a2, err := ConvertArea(1000.0, constants.UnitMeters, constants.UnitKilometers)
+	assert.Equal(t, err, nil)
+	assert.Equal(t, a2, 0.001)
+
 	b, err := ConvertArea(1, constants.UnitKilometers, constants.UnitMiles)
 	assert.Equal(t, err, nil)
 	assert.Equal(t, b, 0.386)
@@ -132,13 +136,25 @@ func TestConvertArea(t *testing.T) {
 	assert.Equal(t, err, nil)
 	assert.Equal(t, d, 10000.0)
 
-	k, err := ConvertArea(1, constants.UnitMeters, constants.UnitCentimetres)
+	d2, err := ConvertArea(1, constants.UnitMeters, constants.UnitCentimetres)
 	assert.Equal(t, err, nil)
-	assert.Equal(t, k, 10000.0)
+	assert.Equal(t, d2, 10000.0)
+
+	d3, err := ConvertArea(1, constants.UnitMetres, constants.UnitCentimetres)
+	assert.Equal(t, err, nil)
+	assert.Equal(t, d3, 10000.0)
+
+	d4, err := ConvertArea(1, constants.UnitMetres, constants.UnitCentimeters)
+	assert.Equal(t, err, nil)
+	assert.Equal(t, d4, 10000.0)
 
 	f, err := ConvertArea(100, constants.UnitMeters, constants.UnitAcres)
 	assert.Equal(t, err, nil)
 	assert.Equal(t, f, 0.0247105)
+
+	f2, err := ConvertArea(100, constants.UnitMetres, constants.UnitAcres)
+	assert.Equal(t, err, nil)
+	assert.Equal(t, f2, 0.0247105)
 
 	g, err := ConvertArea(100, "", constants.UnitYards)
 	assert.Equal(t, err, nil)
@@ -148,6 +164,10 @@ func TestConvertArea(t *testing.T) {
 	assert.Equal(t, err, nil)
 	assert.Equal(t, h, 1076.3910417)
 
+	h2, err := ConvertArea(100, constants.UnitMetres, constants.UnitFeet)
+	assert.Equal(t, err, nil)
+	assert.Equal(t, h2, 1076.3910417)
+
 	i, err := ConvertArea(100000, constants.UnitFeet, "")
 	assert.Equal(t, err, nil)
 	assert.Equal(t, i, 0.009290303999749462)
@@ -156,7 +176,14 @@ func TestConvertArea(t *testing.T) {
 	assert.Equal(t, err, nil)
 	assert.Equal(t, j, 0.0001)
 
+	j2, err := ConvertArea(1, constants.UnitMetres, constants.UnitHectares)
+	assert.Equal(t, err, nil)
+	assert.Equal(t, j2, 0.0001)
+
 	_, err = ConvertArea(-1, constants.UnitMeters, constants.UnitMillimeters)
+	assert.Equal(t, err.Error(), "area must be a positive number")
+
+	_, err = ConvertArea(-1, constants.UnitMetres, constants.UnitMillimeters)
 	assert.Equal(t, err.Error(), "area must be a positive number")
 
 	_, err = ConvertArea(1, "foo", "bar")

--- a/conversions/conversions_test.go
+++ b/conversions/conversions_test.go
@@ -132,6 +132,10 @@ func TestConvertArea(t *testing.T) {
 	assert.Equal(t, err, nil)
 	assert.Equal(t, d, 10000.0)
 
+	k, err := ConvertArea(1, constants.UnitMeters, constants.UnitCentimetres)
+	assert.Equal(t, err, nil)
+	assert.Equal(t, k, 10000.0)
+
 	f, err := ConvertArea(100, constants.UnitMeters, constants.UnitAcres)
 	assert.Equal(t, err, nil)
 	assert.Equal(t, f, 0.0247105)

--- a/conversions/conversions_test.go
+++ b/conversions/conversions_test.go
@@ -115,6 +115,53 @@ func TestConvertLength(t *testing.T) {
 
 }
 
+func TestConvertArea(t *testing.T) {
+	a, err := ConvertArea(1000.0, constants.UnitMetres, constants.UnitKilometers)
+	assert.Equal(t, err, nil)
+	assert.Equal(t, a, 0.001)
+
+	b, err := ConvertArea(1, constants.UnitKilometers, constants.UnitMiles)
+	assert.Equal(t, err, nil)
+	assert.Equal(t, b, 0.386)
+
+	c, err := ConvertArea(1, constants.UnitMiles, constants.UnitKilometers)
+	assert.Equal(t, err, nil)
+	assert.Equal(t, c, 2.5906735751295336)
+
+	d, err := ConvertArea(1, constants.UnitMeters, constants.UnitCentimeters)
+	assert.Equal(t, err, nil)
+	assert.Equal(t, d, 10000.0)
+
+	f, err := ConvertArea(100, constants.UnitMeters, constants.UnitAcres)
+	assert.Equal(t, err, nil)
+	assert.Equal(t, f, 0.0247105)
+
+	g, err := ConvertArea(100, "", constants.UnitYards)
+	assert.Equal(t, err, nil)
+	assert.Equal(t, g, 119.59900459999999)
+
+	h, err := ConvertArea(100, constants.UnitMeters, constants.UnitFeet)
+	assert.Equal(t, err, nil)
+	assert.Equal(t, h, 1076.3910417)
+
+	i, err := ConvertArea(100000, constants.UnitFeet, "")
+	assert.Equal(t, err, nil)
+	assert.Equal(t, i, 0.009290303999749462)
+
+	j, err := ConvertArea(1, constants.UnitMeters, constants.UnitHectares)
+	assert.Equal(t, err, nil)
+	assert.Equal(t, j, 0.0001)
+
+	_, err = ConvertArea(-1, constants.UnitMeters, constants.UnitMillimeters)
+	assert.Equal(t, err.Error(), "area must be a positive number")
+
+	_, err = ConvertArea(1, "foo", "bar")
+	assert.Equal(t, err.Error(), "invalid original units")
+
+	_, err = ConvertArea(1, constants.UnitMeters, "bar")
+	assert.Equal(t, err.Error(), "invalid finalUnits units")
+}
+
 func TestDegreesToRadians(t *testing.T) {
 	r := DegreesToRadians(180)
 


### PR DESCRIPTION
This PR ports the ConvertArea function.
ConvertArea is a function that converts an area to the requested units.